### PR TITLE
disabled dial rotation

### DIFF
--- a/Assets/Scenes/Main_Scene.unity
+++ b/Assets/Scenes/Main_Scene.unity
@@ -740,7 +740,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 50081257}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: bab461c1623b44b6cb36add12f4d8bc9, type: 3}
   m_Name: 
@@ -2488,7 +2488,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 592094871}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: bab461c1623b44b6cb36add12f4d8bc9, type: 3}
   m_Name: 


### PR DESCRIPTION
circle doesnt move around anymore so now the dial is not messed up (disabled the component containing the dial rotation script in both italicssaydialogue and normalsaydialogue)